### PR TITLE
Fix issues when testing on localhost

### DIFF
--- a/public/js/debuginfo.js
+++ b/public/js/debuginfo.js
@@ -71,7 +71,6 @@ const showSimpleIDVResults = function (results) {
     "#idvAttTos": "accept_tos",
     "#idvAttSMS": "verify_sms",
     "#idvAttKYC": "kyc_check",
-    "#idvAttSMS": "verify_sms",
     "#idvAttRisk": "risk_check",
     "#idvAttDocs": "documentary_verification",
     "#idvAttSelfie": "selfie_check",

--- a/server.js
+++ b/server.js
@@ -105,6 +105,8 @@ app.post("/server/create_new_user", async (req, res, next) => {
       res.cookie("signedInUser", userId, {
         maxAge: 900000,
         httpOnly: true,
+        sameSite: "none",
+        secure: "false",
       });
     }
     res.json(result);
@@ -119,6 +121,8 @@ app.post("/server/sign_in", async (req, res, next) => {
     res.cookie("signedInUser", userId, {
       maxAge: 900000,
       httpOnly: true,
+      sameSite: "none",
+      secure: "false",
     });
     res.json({ signedIn: true });
   } catch (error) {


### PR DESCRIPTION
When using case-sensitive file systems (e.g., Linux), the loading of debuginfo.js fails.
Also, if the SameSite attribute is not set, the server cookie is blocked by default.