### PR TITLE
Update IDV templates URL to dashboard.plaid.com

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ You can keep `sandbox` as your environment.
 
 For `TEMPLATE_ID`, we'll need the ID of the Identity Verification template that
 you created above. You can do this by selecting your template from the
-[templates screen](https://idv-playground.plaid.com/flow/templates/), selecting
+[templates screen](https://dashboard.plaid.com/sandbox/identity_verification/templates), selecting
 the template you created, and then clicking the **Integration** button on top.
 
 You can leave `DATA_SOURCE_ONLY_NO_SMS_ID` blank for now. We'll return to this in


### PR DESCRIPTION
The README pointed users at \`https://idv-playground.plaid.com/flow/templates/\`. That host is still up but serves a cert for a different domain (TLS handshake fails), so browsers show a security warning. The IDV templates UI is now under the main Plaid Dashboard at \`https://dashboard.plaid.com/sandbox/identity_verification/templates\` (verified 200).

## Test plan
- [ ] Click the "templates screen" link in the rendered README and confirm it lands on the Dashboard IDV templates page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 80ee54fa-3880-4c3c-b81d-9bf74c3adb2c