### PR TITLE
Fix small correctness bugs in the IDV sample

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -134,8 +134,8 @@
       <div id="output"></div>
     </div>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
     crossorigin="anonymous"></script>
   <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
   <script type="module" src="js/client.js"></script>

--- a/public/js/debuginfo.js
+++ b/public/js/debuginfo.js
@@ -36,9 +36,11 @@ export const getIDVList = async function () {
   const starterOption = `<option value=""> -- Pick one--  </option>`;
   document.querySelector("#listOfAttempts").innerHTML =
     starterOption +
-    savedAttemptData.map((result) => {
-      return `<option value="${result["id"]}">${result["created_at"]}</value>`;
-    });
+    savedAttemptData
+      .map((result) => {
+        return `<option value="${result["id"]}">${result["created_at"]}</option>`;
+      })
+      .join("");
   showSelector("#listOfAttempts");
 };
 

--- a/public/js/signin.js
+++ b/public/js/signin.js
@@ -25,9 +25,11 @@ const getExistingUsers = async function () {
     hideSelector("#existingUsers");
   } else {
     showSelector("#existingUsers");
-    document.querySelector("#existingUsersSelect").innerHTML = usersList.map(
-      (userObj) => `<option value="${userObj.id}">${userObj.username}</option>`
-    );
+    document.querySelector("#existingUsersSelect").innerHTML = usersList
+      .map(
+        (userObj) => `<option value="${userObj.id}">${userObj.username}</option>`
+      )
+      .join("");
   }
 };
 

--- a/server.js
+++ b/server.js
@@ -106,7 +106,7 @@ app.post("/server/create_new_user", async (req, res, next) => {
         maxAge: 900000,
         httpOnly: true,
         sameSite: "none",
-        secure: "false",
+        secure: false,
       });
     }
     res.json(result);
@@ -122,7 +122,7 @@ app.post("/server/sign_in", async (req, res, next) => {
       maxAge: 900000,
       httpOnly: true,
       sameSite: "none",
-      secure: "false",
+      secure: false,
     });
     res.json({ signedIn: true });
   } catch (error) {
@@ -530,6 +530,4 @@ const errorHandler = function (err, req, res, next) {
 };
 app.use(errorHandler);
 
-const webhookServer = getWebhookServer();
-
-exports.updateUserRecordForIDVSession = updateUserRecordForIDVSession;
+const webhookServer = getWebhookServer(updateUserRecordForIDVSession);

--- a/webhookServer.js
+++ b/webhookServer.js
@@ -1,7 +1,10 @@
 const express = require("express");
 const bodyParser = require("body-parser");
 
-const serverFunctions = require("./server");
+// The main server injects this via getWebhookServer() so that this file
+// doesn't need to require("./server") -- that would create a circular
+// dependency between the two modules.
+let onStatusUpdated = () => {};
 
 /**
  * This is a separate server running on a different port that we use
@@ -76,7 +79,7 @@ function handleIdVerWebhook(code, requestBody) {
       console.log(
         `Webhook report: The status has been updated for IDV session ${idvSession}. Let's update our database.`
       );
-      serverFunctions.updateUserRecordForIDVSession(idvSession);
+      onStatusUpdated(idvSession);
       break;
     default:
       console.log(`I'm not doing anything with the ${code} webhook.`);
@@ -103,7 +106,10 @@ const errorHandler = function (err, req, res, next) {
 
 webhookApp.use(errorHandler);
 
-const getWebhookServer = function () {
+const getWebhookServer = function (statusUpdatedHandler) {
+  if (statusUpdatedHandler != null) {
+    onStatusUpdated = statusUpdatedHandler;
+  }
   return webhookServer;
 };
 


### PR DESCRIPTION
Four small, self-contained bug fixes surfaced by a code-quality pass over the sample. None change the intended teaching flows; they just correct things that are plainly wrong regardless of this being a demo app.

- **`secure: "false"` cookie flag** (`server.js`) — the string `"false"` is truthy, so Express was emitting the `Secure` attribute rather than clearing it (the opposite of intent). Changed to the boolean `false` so the cookie behaves as expected over `http://localhost`.
- **Broken `<option>` markup** (`debuginfo.js`) — options were closed with `</value>` and, in both `debuginfo.js` and `signin.js`, a `.map()` array was assigned straight to `innerHTML`, coercing to a comma-separated string. Fixed the closing tag and added `.join("")`.
- **Bootstrap version mismatch** (`index.html`) — the CDN bundle was pinned to `5.0.2` while `package.json` (and the compiled custom SCSS) use `^5.3.8`. Bumped the CDN script to `5.3.8` with a matching SRI hash.
- **Circular `require`** — `server.js` and `webhookServer.js` required each other. `webhookServer.js` now receives the status-updated handler via `getWebhookServer(updateUserRecordForIDVSession)` instead of `require("./server")`, making the dependency one-directional.

Verified both servers still boot (ports 8000/8001) and the DB initializes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)