### PR TITLE
Set sign-in cookie to SameSite=Lax so it persists

### DIFF
--- a/server.js
+++ b/server.js
@@ -105,7 +105,7 @@ app.post("/server/create_new_user", async (req, res, next) => {
       res.cookie("signedInUser", userId, {
         maxAge: 900000,
         httpOnly: true,
-        sameSite: "none",
+        sameSite: "lax",
         secure: false,
       });
     }
@@ -121,7 +121,7 @@ app.post("/server/sign_in", async (req, res, next) => {
     res.cookie("signedInUser", userId, {
       maxAge: 900000,
       httpOnly: true,
-      sameSite: "none",
+      sameSite: "lax",
       secure: false,
     });
     res.json({ signedIn: true });


### PR DESCRIPTION
Follow-up to #43. That PR changed the `signedInUser` cookie to `secure: false` but left `sameSite: "none"` — and browsers reject a `SameSite=None` cookie that lacks the `Secure` attribute, so the cookie was silently discarded and sign-in never persisted (the server saw `Your userID is undefined` on every request).

Every request in this app is same-origin (`localhost:8000` → itself), so `SameSite=Lax` is the correct setting and needs no `Secure` flag over `http://localhost`.

Verified in a browser: creating an account now transitions the UI to the signed-in state ("Signed in as …") and the server logs a real user ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)